### PR TITLE
Add `language`; support finalized=true for creating invoices

### DIFF
--- a/invoices.go
+++ b/invoices.go
@@ -40,6 +40,7 @@ type InvoiceBody struct {
 	Title              string                        `json:"title"`
 	Introduction       string                        `json:"introduction"`
 	Remark             string                        `json:"remark"`
+	Language           string                        `json:"language"`
 }
 
 type InvoiceBodyAddress struct {


### PR DESCRIPTION
I have not tried this but this is what the docs say at least. There doesn't seem to be a way to create an invoice in anything other than `draft` or `open` status via the API.