### PR TITLE
Misc fixes

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -73,6 +73,7 @@ func TestRateLimit(t *testing.T) {
 		if rateLimitHits > 0 {
 			rateLimitHits -= 1
 			w.WriteHeader(http.StatusTooManyRequests)
+			//nolint:errcheck
 			w.Write([]byte(`{
 				"status": 429,
 				"error": "Too Many Requests",

--- a/errors_test.go
+++ b/errors_test.go
@@ -67,6 +67,41 @@ func TestErrorNoDetails(t *testing.T) {
 	})
 }
 
+func TestRateLimit(t *testing.T) {
+	rateLimitHits := 10
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if rateLimitHits > 0 {
+			rateLimitHits -= 1
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{
+				"status": 429,
+				"error": "Too Many Requests",
+				"message": "Rate limit exceeded"
+			}`))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck
+		}
+	}))
+	defer server.Close()
+
+	lexOffice := golexoffice.NewConfig("token", nil)
+	lexOffice.SetBaseUrl(server.URL)
+
+	t.Run("retry until ok", func(t *testing.T) {
+		rateLimitHits = 2
+		_, err := lexOffice.Invoice("tralalala")
+		assert.NoError(t, err)
+	})
+
+	t.Run("retry until out of retries", func(t *testing.T) {
+		rateLimitHits = 10
+		_, err := lexOffice.Invoice("tralalala")
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "Rate limit exceeded")
+	})
+}
+
 func errorMock() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/contacts/" {

--- a/invoices.go
+++ b/invoices.go
@@ -14,8 +14,6 @@ package golexoffice
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"io"
 )
 
 // InvoiceBody is to define body data
@@ -133,12 +131,6 @@ func (c *Config) Invoice(id string) (InvoiceBody, error) {
 
 	// Close request
 	defer response.Body.Close()
-
-	read, err := io.ReadAll(response.Body)
-	if err != nil {
-		return InvoiceBody{}, err
-	}
-	fmt.Println(string(read))
 
 	// Decode data
 	var decode InvoiceBody

--- a/invoices.go
+++ b/invoices.go
@@ -35,7 +35,7 @@ type InvoiceBody struct {
 	TotalPrice         InvoiceBodyTotalPrice         `json:"totalPrice"`
 	TaxAmounts         []InvoiceBodyTaxAmounts       `json:"taxAmounts,omitempty"`
 	TaxConditions      InvoiceBodyTaxConditions      `json:"taxConditions"`
-	PaymentConditions  *InvoiceBodyPaymentConditions  `json:"paymentConditions,omitempty"`
+	PaymentConditions  *InvoiceBodyPaymentConditions `json:"paymentConditions,omitempty"`
 	ShippingConditions InvoiceBodyShippingConditions `json:"shippingConditions"`
 	Title              string                        `json:"title,omitempty"`
 	Introduction       string                        `json:"introduction,omitempty"`
@@ -58,26 +58,26 @@ type InvoiceBodyLineItems struct {
 	Type               string               `json:"type"`
 	Name               string               `json:"name"`
 	Description        string               `json:"description,omitempty"`
-	Quantity           float64              `json:"quantity,omitempty"`
+	Quantity           interface{}          `json:"quantity,omitempty"`
 	UnitName           string               `json:"unitName,omitempty"`
 	UnitPrice          InvoiceBodyUnitPrice `json:"unitPrice,omitempty"`
-	DiscountPercentage int                  `json:"discountPercentage,omitempty"`
-	LineItemAmount     float64              `json:"lineItemAmount,omitempty"`
+	DiscountPercentage interface{}          `json:"discountPercentage,omitempty"`
+	LineItemAmount     interface{}          `json:"lineItemAmount,omitempty"`
 }
 
 type InvoiceBodyUnitPrice struct {
-	Currency          string  `json:"currency"`
-	NetAmount         float64 `json:"netAmount,omitempty"`
-	GrossAmount       float64 `json:"grossAmount,omitempty"`
-	TaxRatePercentage int     `json:"taxRatePercentage"`
+	Currency          string      `json:"currency"`
+	NetAmount         interface{} `json:"netAmount,omitempty"`
+	GrossAmount       interface{} `json:"grossAmount,omitempty"`
+	TaxRatePercentage int         `json:"taxRatePercentage"`
 }
 
 type InvoiceBodyTotalPrice struct {
 	Currency                string      `json:"currency"`
-	TotalNetAmount          float64     `json:"totalNetAmount,omitempty"`
-	TotalGrossAmount        float64     `json:"totalGrossAmount,omitempty"`
+	TotalNetAmount          interface{} `json:"totalNetAmount,omitempty"`
+	TotalGrossAmount        interface{} `json:"totalGrossAmount,omitempty"`
 	TaxRatePercentage       interface{} `json:"taxRatePercentage,omitempty"`
-	TotalTaxAmount          float64     `json:"totalTaxAmount,omitempty"`
+	TotalTaxAmount          interface{} `json:"totalTaxAmount,omitempty"`
 	TotalDiscountAbsolute   interface{} `json:"totalDiscountAbsolute,omitempty"`
 	TotalDiscountPercentage interface{} `json:"totalDiscountPercentage,omitempty"`
 }

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -1,16 +1,86 @@
 package golexoffice_test
 
 import (
+	"encoding/json"
 	"testing"
-    "encoding/json"
 
 	"github.com/hostwithquantum/golexoffice"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEmptyInvoiceOnlyHasRequiredProperties(t *testing.T) {
-    body := golexoffice.InvoiceBody{}
+	body := golexoffice.InvoiceBody{}
 	encoded, err := json.Marshal(body)
-    assert.NoError(t, err)
-    assert.Equal(t, `{"voucherDate":"","address":{},"lineItems":null,"totalPrice":{"currency":""},"taxConditions":{"taxType":""},"shippingConditions":{"shippingType":""}}`, string(encoded))
+	assert.NoError(t, err)
+	assert.JSONEq(t, `
+    {
+      "voucherDate": "",
+      "address": {},
+      "lineItems": null,
+      "totalPrice": {
+        "currency": ""
+      },
+      "taxConditions": {
+        "taxType": ""
+      },
+      "shippingConditions": {
+        "shippingType": ""
+      }
+    }`, string(encoded))
+}
+
+func TestPriceOfZeroIsNotOmitted(t *testing.T) {
+	body := golexoffice.InvoiceBody{
+		TotalPrice: golexoffice.InvoiceBodyTotalPrice{
+			TotalGrossAmount: 0,
+		},
+		LineItems: []golexoffice.InvoiceBodyLineItems{
+			{
+				UnitPrice: golexoffice.InvoiceBodyUnitPrice{
+					NetAmount: 0.0,
+				},
+			},
+			{
+				UnitPrice: golexoffice.InvoiceBodyUnitPrice{
+					GrossAmount: 0.0,
+				},
+			}},
+	}
+	encoded, err := json.Marshal(body)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `
+    {
+      "voucherDate": "",
+      "address": {},
+      "lineItems": [
+          {
+            "name": "",
+            "type": "",
+            "unitPrice": {
+              "currency": "",
+              "taxRatePercentage": 0,
+              "netAmount": 0
+            }
+          },
+          {
+            "name": "",
+            "type": "",
+            "unitPrice": {
+              "currency": "",
+              "taxRatePercentage": 0,
+              "grossAmount": 0
+            }
+          }
+      ],
+      "totalPrice": {
+        "currency": "",
+        "totalGrossAmount": 0
+      },
+      "taxConditions": {
+        "taxType": ""
+      },
+      "shippingConditions": {
+        "shippingType": ""
+      }
+    }`, string(encoded))
 }


### PR DESCRIPTION
* don't omit prices of 0 €  in the invoice POST body (not handled very elegantly, with `interface{}` but the only other easy alternative is a `*float64` and that makes the client code look ugly)
* automatically do up to 3 retries after hitting a request limit
* fix `Invoice` getter reading the response body twice (just stumbled upon this)